### PR TITLE
Update OPRF_Finalize algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ venv/
 lib
 draft-irtf-cfrg-voprf.xml
 draft-irtf-cfrg-voprf.txt
+.vscode/


### PR DESCRIPTION
It is helpful in some applications to allow finalization over specific data. This change is based on the existing PR for protocol integrations and so needs to be merged into that branch before master.

Changes:
- Allows finalization over auxiliary data