### PR TITLE
Specify modifications in batching paradigm

### DIFF
--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -387,14 +387,53 @@ In the following, we may also refer to this commitment as a public key.
 
 ## Prime-order group instantiation
 
-- description (operations, order etc.)
-- instantiations (curves, cofactor considerations)
+In this document, we assume the construction of a prime-order group GG for
+performing all mathematical operations. Such a group MUST provide the interface
+provided by cyclic group under the addition operation (for example, well-defined
+addition of group elements). We also assume the presence of a fixed generator G
+that can be detailed as a fixed parameter in the description of the group. We
+write p = order(GG) to represent the order of the group throughout this
+document.
+
+It is common in cryptographic applications to instantiate such prime-order
+groups using elliptic curves, such as those detailed in {{SEC2}}. For some
+choices of elliptic curves (e.g. those detailed in {{RFC7748}} require
+accounting for cofactors) there are some implementation issues that introduce
+inherent discrepancies between standard prime-order groups and the elliptic
+curve instantiation. In this document, all algorithms that we detail assume that
+the group is a prime-order group, and this MUST be upheld by any implementer.
+That is, any curve instantiation shoudl be written such that any discrepancies
+with a prime-order group instantiation are removed. In the case of cofactors,
+for example, this can be done by building cofactor multiplication into all
+elliptic curve operations.
 
 ## Conventions
 
-- {0,1}^*
-- uniform sampling
-- point, scalar notation
+We detail a list of conventions that we use throughout this document.
+
+### Binary strings
+
+- We use the notation x <-$ Q to denote sampling x from the uniform distribution
+  over the set Q.
+- We use x <- {0,1}^u to denote sampling x uniformly from the set of binary
+  strings of length u. We may interpret x afterwards as a byte array.
+- We say that x is a binary string of arbitrary-length (or alternatively sampled
+  from {0,1}^*) if there is no fixed-size requirement on x.
+- For two byte arrays x & y, write x .. y to denote their concatenation.
+
+### Group notation
+
+- We use the letter p to denote the order of a group GG throughout, where the
+  instantiation of the specific group is defined by context.
+- For elements A & B of GG, we write A + B to denote the addition of thr group
+  elements.
+- We use GF(p) to denote the Galois Field of scalar values associated with the
+  group GG.
+- For a scalar r in GF(p), and a group element A, we write rA to denote the
+  scalar multiplication of A.
+- For two scalars r, s in GF(p), we use r+s to denote the resulting scalar in
+  GF(p) (we may optionally write r+s mod p to make the modular reduction
+  explicit).
 
 # OPRF Protocol {#protocol}
 
@@ -441,15 +480,14 @@ random oracles. Let L be the security parameter. Let k be the prover's secret
 key, and Y = kG be its corresponding 'public key' for some fixed generator G
 taken from the description of the group GG. This public key Y is also referred
 to as a commitment to the OPRF key k, and the pair (G,Y) as a commitment pair.
-Let x be the verifier's input to the OPRF protocol (commonly, it is a random
-L-bit string, though this is not required).
+Let x be the binary string that is the verifier's input to the OPRF protocol
+(this can be of arbitrary length).
 
 The OPRF protocol begins with V blinding its input for the OPRF evaluator such
 that it appears uniformly distributed GG. The latter then applies its secret key
 to the blinded value and returns the result. To finish the computation, V then
 removes its blind and hashes the result (along with a domain separating label
-DST) using H_2 to yield an output. This flow is illustrated below. We use the
-notation x .. N to denote the concatenation of the bytes of x and N.
+DST) using H_2 to yield an output. This flow is illustrated below.
 
 ~~~
      Verifier(x)                   Prover(k)

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -1,7 +1,7 @@
 ---
 title: Oblivious Pseudorandom Functions (OPRFs) using Prime-Order Groups
 abbrev: OPRFs
-docname: draft-irtf-cfrg-voprf-latest-00
+docname: draft-irtf-cfrg-voprf-latest
 date:
 category: info
 

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -533,7 +533,7 @@ embedding (V)OPRF protocols into wider protocols in {{embed}}.
 This protocol may be decomposed into a series of steps, as described below:
 
 - OPRF_Setup(l): Let GG=GG(l) be a group with a prime-order p=p(l) (e.g., p is
-  l-bits long). Randomly sample an integer k in GF(p) and output (k,p)
+  l-bits long). Randomly sample an integer k in GF(p) and output (k,GG)
 - OPRF_Blind(x): Compute and return a blind, r, and blinded representation of x
   in GG, denoted M.
 - OPRF_Eval(k,M,h?): Evaluates on input M using secret key k to produce Z, the
@@ -547,8 +547,8 @@ This protocol may be decomposed into a series of steps, as described below:
 For verifiability (VOPRF) we modify the algorithms of VOPRF_Setup, VOPRF_Eval
 and VOPRF_Unblind to be the following:
 
-- VOPRF_Setup(l): Run (k,p) = OPRF_Setup(l), compute Y = kG, where G is a
-  generator of the group GG. Output (k,p,Y).
+- VOPRF_Setup(l): Run (k,GG) = OPRF_Setup(l), compute Y = kG, where G is a
+  generator of the group GG. Output (k,GG,Y).
 - VOPRF_Eval(k,G,Y,M,h?): Evaluates on input M using secret key k to produce Z.
   Generate a NIZK proof D = DLEQ_Generate(k,G,Y,M,Z), and output (Z, D). The
   optional cofactor h can also be provided, as in OPRF_Eval.
@@ -571,8 +571,8 @@ OPRF setup phase:
 ~~~
      Verifier()                   Prover(l)
   ----------------------------------------------------------
-                                  (k,p) = OPRF_Setup(l)
-                            p
+                                  (k,GG) = OPRF_Setup(l)
+                           GG
                         <-------
 ~~~
 
@@ -607,8 +607,8 @@ VOPRF setup phase:
 ~~~
      Verifier()                   Prover(l)
   ----------------------------------------------------------
-                                  (k,p,Y) = VOPRF_Setup(l)
-                          (p,Y)
+                                  (k,GG,Y) = VOPRF_Setup(l)
+                         (GG,Y)
                         <-------
 ~~~
 
@@ -652,7 +652,7 @@ auxiliary data aux.
 
 ## Instantiations of GG
 
-As we remarked above, GG is a subgroup with associated prime-order p. While we
+As we remarked above, GG is a group with associated prime-order p. While we
 choose to write operations in the setting where GG comes equipped with an
 additive operation, we could also define the operations in the multiplicative
 setting. In the multiplicative setting we can choose GG to be a prime-order
@@ -1029,13 +1029,12 @@ as single evaluations.
 
 ### Setup phase
 
-In the VOPRF setting, the server must send to the client (p,Y) where p is the
-prime used in instantiating the group used for the VOPRF operations, and Y is a
-commitment to the server key k. From this information, the client and server
-must agree on a generator G for the group description. It is important that the
-generator G of GG is not chosen by the server, and that it is agreed upon before
-the protocol starts. In the elliptic curve setting, we recommend that G is
-chosen as the standard generator for the curve.
+In the VOPRF setting, the server must send to the client Y (the commitment to
+the server key k. From this information, the client and server must agree on a
+generator G for the group description. It is important that the generator G of
+GG is not chosen by the server, and that it is agreed upon before the protocol
+starts. In the elliptic curve setting, we recommend that G is chosen as the
+standard generator for the curve.
 
 As we mentioned above, if an implementer wants to embed OPRF evaluation as part
 of a wider protocol, then we recommend that this setup phase should occur before
@@ -1115,10 +1114,11 @@ Output:
 Steps:
 
  1. r <-$ GF(p)
- 2. A := rG and B := rM
- 3. c <- H_3(G,Y,M,Z,A,B) (mod p)
- 4. s := (r - ck) (mod p)
- 5. Output D := (c, s)
+ 2. A := rG
+ 3. B := rM
+ 4. c <- H_3(G,Y,M,Z,A,B) (mod p)
+ 5. s := (r - ck) (mod p)
+ 6. Output D := (c, s)
 ~~~
 
 We note here that it is essential that a different r value is used for every
@@ -1204,7 +1204,7 @@ Steps:
 
  1. seed <- H_4(G,Y,[Mi,Zi]))
  2. i' := i
- 3. for i in [n]:
+ 3. for i in [m]:
     1. di <- H_5(seed,i',info)
     2. if di > p:
        1. i' = i'+1
@@ -1235,7 +1235,7 @@ Steps:
 
  1. seed <- H_4(G,Y,[Mi,Zi]))
  2. i' := i
- 3. for i in [n]:
+ 3. for i in [m]:
     1. di <- H_5(seed,i',info)
     2. if di > p:
        1. i' = i'+1
@@ -1250,8 +1250,8 @@ Steps:
 ## Modified algorithms
 
 The VOPRF protocol from Section {{protocol}} changes to allow specifying
-multiple blinded PRF inputs [ Mi ] for i in 1...n. P computes the array [ Zi ]
-and replaces DLEQ_Generate with DLEQ_Batched_Generate over these arrays.
+multiple blinded PRF inputs `[ Mi ]` for i in 1...n. P computes the array `[ Zi
+]` and replaces DLEQ_Generate with DLEQ_Batched_Generate over these arrays.
 Concretely, we modify the following algorithms:
 
 ### VOPRF_Blind
@@ -1449,8 +1449,7 @@ as single evaluations.
 
 ## Setup phase
 
-In the VOPRF setting, the server must send to the client (p,Y) where p is the
-prime used in instantiating the group used for the VOPRF operations, and Y is a
+In the VOPRF setting, the server must send Y to the client where Y is a
 commitment to the server key k. From this information, the client and server
 must agree on a generator G for the group description. It is important that the
 generator G of GG is not chosen by the server, and that it is agreed upon before

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -1,7 +1,7 @@
 ---
 title: Oblivious Pseudorandom Functions (OPRFs) using Prime-Order Groups
 abbrev: OPRFs
-docname: draft-irtf-cfrg-voprf-latest
+docname: draft-irtf-cfrg-voprf-latest-00
 date:
 category: info
 
@@ -46,12 +46,15 @@ normative:
   NIST:
     title: Keylength - NIST Report on Cryptographic Key Length and Cryptoperiod (2016)
     target: https://www.keylength.com/en/4/
+    date: false
   PrivacyPass:
     title: Privacy Pass
     target: https://github.com/privacypass/challenge-bypass-server
+    date: false
   ChaumPedersen:
     title: Wallet Databases with Observers
     target: https://chaum.com/publications/Wallet_Databases.pdf
+    date: false
     authors:
         -
           ins: D. Chaum
@@ -62,6 +65,7 @@ normative:
   ChaumBlindSignature:
     title: Blind Signatures for Untraceable Payments
     target: http://sceweb.sce.uhcl.edu/yang/teaching/csci5234WebSecurityFall2011/Chaum-blind-signatures.PDF
+    date: false
     authors:
       -
         ins: D. Chaum
@@ -69,6 +73,7 @@ normative:
   BB04:
     title: Short Signatures Without Random Oracles
     target: http://ai.stanford.edu/~xb/eurocrypt04a/bbsigs.pdf
+    date: false
     authors:
       -
         ins: D. Boneh
@@ -79,6 +84,7 @@ normative:
   BG04:
     title: The Static Diffie-Hellman Problem
     target: https://eprint.iacr.org/2004/306
+    date: false
     authors:
       -
         ins: D. Brown
@@ -89,6 +95,7 @@ normative:
   Cheon06:
     title: Security Analysis of the Strong Diffie-Hellman Problem
     target: https://www.iacr.org/archive/eurocrypt2006/40040001/40040001.pdf
+    date: false
     authors:
       -
         ins: J. H. Cheon
@@ -96,6 +103,7 @@ normative:
   JKKX16:
     title: Highly-Efficient and Composable Password-Protected Secret Sharing (Or, How to Protect Your Bitcoin Wallet Online)
     target: https://eprint.iacr.org/2016/144
+    date: false
     authors:
       -
         ins: S. Jarecki
@@ -112,6 +120,7 @@ normative:
   JKK14:
     title:  Round-Optimal Password-Protected Secret Sharing and T-PAKE in the Password-Only model
     target: https://eprint.iacr.org/2014/650
+    date: false
     authors:
       -
         ins: S. Jarecki
@@ -126,6 +135,7 @@ normative:
     title: >
       TOPPSS: Cost-minimal Password-Protected Secret Sharing based on Threshold OPRF
     target: https://eprint.iacr.org/2017/363
+    date: false
     authors:
       -
         ins: S. Jarecki
@@ -142,6 +152,7 @@ normative:
   SJKS17:
     title:  SPHINX, A Password Store that Perfectly Hides from Itself
     target: https://eprint.iacr.org/2018/695
+    date: false
     authors:
       -
         ins: M. Shirvanian
@@ -158,6 +169,7 @@ normative:
   DGSTV18:
     title: Privacy Pass, Bypassing Internet Challenges Anonymously
     target: https://www.degruyter.com/view/j/popets.2018.2018.issue-3/popets-2018-0026/popets-2018-0026.xml
+    date: false
     authors:
       -
         ins: A. Davidson
@@ -177,6 +189,7 @@ normative:
   RISTRETTO:
     title: The ristretto255 Group
     target: https://tools.ietf.org/html/draft-hdevalence-cfrg-ristretto-01
+    date: false
     authors:
       -
         ins: H. de Valence
@@ -191,6 +204,7 @@ normative:
   DECAF:
     title: Decaf, Eliminating cofactors through point compression
     target: https://www.shiftleft.org/papers/decaf/decaf.pdf
+    date: false
     authors:
       -
         ins: M. Hamburg
@@ -198,6 +212,7 @@ normative:
   OPAQUE:
     title: The OPAQUE Asymmetric PAKE Protocol
     target: https://tools.ietf.org/html/draft-krawczyk-cfrg-opaque-02
+    date: false
     authors:
       -
         ins: H. Krawczyk
@@ -205,6 +220,7 @@ normative:
   SHAKE:
     title: SHA-3 Standard, Permutation-Based Hash and Extendable-Output Functions
     target: https://www.nist.gov/publications/sha-3-standard-permutation-based-hash-and-extendable-output-functions?pub_id=919061
+    date: false
     authors:
       -
         ins: Morris J. Dworkin
@@ -212,12 +228,14 @@ normative:
   SEC2:
     title: "SEC 2: Recommended Elliptic Curve Domain Parameters"
     target: http://www.secg.org/sec2-v2.pdf
+    date: false
     author:
       -
         ins: Standards for Efficient Cryptography Group (SECG)
   keytrans:
     title: "Security Through Transparency"
     target: https://security.googleblog.com/2017/01/security-through-transparency.html
+    date: false
     authors:
       -
         ins: Ryan Hurst


### PR DESCRIPTION
Fixes #62.

- Previously batched versions of VOPRF_Eval, VOPRF_Blind and VOPRF_Unblind were not specified.
- This change provides descriptions accepting with a modified API to allow for batched inputs/outputs.
- Also change the way that we describe inputs and outputs to be more generic.
- Describe conventions around the way that we talk about groups.
- Provide some more context for notation that is used.