### PR TITLE
Remove serialized generator from the context string.

### DIFF
--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -744,12 +744,11 @@ Output:
 
 def GenerateProof(skS, pkS, blindToken, element)
   G = GG.Generator()
-  gen = GG.Serialize(G)
 
   blindTokenList = [blindToken]
   elementList = [element]
 
-  (a1, a2) = ComputeComposites(gen, pkS, blindTokenList, elementList)
+  (a1, a2) = ComputeComposites(pkS, blindTokenList, elementList)
 
   M = GG.Deserialize(a1)
   r = GG.RandomScalar()
@@ -757,8 +756,7 @@ def GenerateProof(skS, pkS, blindToken, element)
   a4 = GG.Serialize(r * M)
 
   challengeDST = "RFCXXXX-challenge-" || self.contextString
-  h2Input = I2OSP(len(gen), 2) || gen ||
-            I2OSP(len(pkS), 2) || pkS ||
+  h2Input = I2OSP(len(pkS), 2) || pkS ||
             I2OSP(len(a1), 2) || a1 || I2OSP(len(a2), 2) || a2 ||
             I2OSP(len(a3), 2) || a3 || I2OSP(len(a4), 2) || a4 ||
             I2OSP(len(challengeDST), 2) || challengeDST
@@ -796,7 +794,6 @@ used.
 ~~~
 Input:
 
-  SerializedElement gen
   PublicKey pkS
   SerializedElement blindTokens[m]
   SerializedElement elements[m]
@@ -805,11 +802,10 @@ Output:
 
   SerializedElement composites[2]
 
-def ComputeComposites(gen, pkS, blindTokens, elements):
+def ComputeComposites(pkS, blindTokens, elements):
   seedDST = "RFCXXXX-seed-" || self.contextString
   compositeDST = "RFCXXXX-composite-" || self.contextString
-  h1Input = I2OSP(len(gen), 2) || gen ||
-            I2OSP(len(pkS), 2) || pkS ||
+  h1Input = I2OSP(len(pkS), 2) || pkS ||
             I2OSP(len(blindTokens), 2) || blindTokens ||
             I2OSP(len(elements), 2) || elements ||
             I2OSP(len(seedDST), 2) || seedDST
@@ -930,12 +926,11 @@ Output:
 
 def VerifyProof(pkS, blindToken, Ev):
   G = GG.Generator()
-  gen = GG.Serialize(G)
 
   blindTokenList = [blindToken]
   elementList = [Ev.element]
 
-  (a1, a2) = ComputeComposites(gen, pkS, blindTokenList, elementList)
+  (a1, a2) = ComputeComposites(pkS, blindTokenList, elementList)
 
   A' = (Ev.proof[1] * G + Ev.proof[0] * pkS)
   B' = (Ev.proof[1] * M + Ev.proof[0] * Z)
@@ -943,8 +938,7 @@ def VerifyProof(pkS, blindToken, Ev):
   a4 = GG.Serialize(B')
 
   challengeDST = "RFCXXXX-challenge-" || self.contextString
-  h2Input = I2OSP(len(gen), 2) || gen ||
-            I2OSP(len(pkS), 2) || pkS ||
+  h2Input = I2OSP(len(pkS), 2) || pkS ||
             I2OSP(len(a1), 2) || a1 ||
             I2OSP(len(a2), 2) || a2 ||
             I2OSP(len(a3), 2) || a3 ||

--- a/poc/oprf.sage
+++ b/poc/oprf.sage
@@ -217,10 +217,9 @@ class ServerContext(object):
         return (digest == expected_digest)
 
 
-def compute_composites(suite, contextString, Gm, pkS, evaluate_input, evaluate_output):
+def compute_composites(suite, contextString, pkS, evaluate_input, evaluate_output):
     seedDST = _as_bytes("RFCXXXX-seed-") + contextString
-    hash_input = I2OSP(len(Gm), 2) + Gm \
-        + I2OSP(len(pkS), 2) + pkS \
+    hash_input = I2OSP(len(pkS), 2) + pkS \
         + I2OSP(len(evaluate_input), 2) + evaluate_input \
         + I2OSP(len(evaluate_output), 2) + evaluate_output \
         + I2OSP(len(seedDST), 2) + seedDST
@@ -250,9 +249,8 @@ class VerifiableClientContext(ClientContext):
 
     def verify_proof(self, evaluate_input, evaluate_output, pi):
         G = self.suite.group.G
-        Gm = self.suite.group.serialize(G)
         pkSm = self.suite.group.serialize(self.pkS)
-        (a1, a2) = compute_composites(self.suite, self.contextString, Gm, pkSm, evaluate_input, evaluate_output)
+        (a1, a2) = compute_composites(self.suite, self.contextString, pkSm, evaluate_input, evaluate_output)
         M = self.suite.group.deserialize(a1)
         Z = self.suite.group.deserialize(a2)
 
@@ -293,10 +291,9 @@ class VerifiableServerContext(ServerContext):
 
     def generate_proof(self, evaluate_input, evaluate_output):
         G = self.suite.group.G
-        Gm = self.suite.group.serialize(G)
         pkSm = self.suite.group.serialize(self.pkS)
 
-        (a1, a2) = compute_composites(self.suite, self.contextString, Gm, pkSm, evaluate_input, evaluate_output)
+        (a1, a2) = compute_composites(self.suite, self.contextString, pkSm, evaluate_input, evaluate_output)
         M = self.suite.group.deserialize(a1)
 
         r = ZZ(self.suite.group.random_scalar())


### PR DESCRIPTION
The suite ID covers this value, so it's not necessary to include in the hash input.

Closes #147.

Thanks, @davidben!