### PR TITLE
Clarify the expand_message implementation for ristretto255 and decaf448.

### DIFF
--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -937,7 +937,7 @@ and ristretto255. See {{cryptanalysis}} for related discussion.
 
 - Group: decaf448 {{!RISTRETTO}}
   - HashToGroup(): hash_to_decaf448
-    {{!I-D.irtf-cfrg-hash-to-curve}} with DST
+    {{!I-D.irtf-cfrg-hash-to-curve}} with DST =
     "VOPRF05-" || `contextString`, where `contextString` is that which is
     computed in the Setup functions, and `expand_message` set to `expand_message_xmd`
     using SHA-512.

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -984,7 +984,7 @@ and ristretto255. See {{cryptanalysis}} for related discussion.
 
 - Group: P-521 (secp521r1) {{x9.62}}
   - HashToGroup(): P521_XMD:SHA-512_SSWU_RO\_
-    {{!I-D.irtf-cfrg-hash-to-curve}} with DST
+    {{!I-D.irtf-cfrg-hash-to-curve}} with DST =
     "VOPRF05-" || `contextString`, where `contextString` is that which is
     computed in the Setup functions.
   - HashToScalar(): Use hash_to_field from {{!I-D.irtf-cfrg-hash-to-curve}}

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -920,7 +920,7 @@ and ristretto255. See {{cryptanalysis}} for related discussion.
 
 - Group: ristretto255 {{!RISTRETTO=I-D.irtf-cfrg-ristretto255-decaf448}}
   - HashToGroup(): hash_to_ristretto255
-    {{!I-D.irtf-cfrg-hash-to-curve}} with DST
+    {{!I-D.irtf-cfrg-hash-to-curve}} with DST =
     "VOPRF05-" || `contextString`, where `contextString` is that which is
     computed in the Setup functions, and `expand_message` set to `expand_message_xmd`
     using SHA-256.

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -920,9 +920,10 @@ and ristretto255. See {{cryptanalysis}} for related discussion.
 
 - Group: ristretto255 {{!RISTRETTO=I-D.irtf-cfrg-ristretto255-decaf448}}
   - HashToGroup(): hash_to_ristretto255
-    {{!I-D.irtf-cfrg-hash-to-curve}} with DST:
-    "VOPRF05-" || contextString, where `contextString` is that which is
-    computed in the Setup functions.
+    {{!I-D.irtf-cfrg-hash-to-curve}} with DST
+    "VOPRF05-" || `contextString`, where `contextString` is that which is
+    computed in the Setup functions, and `expand_message` set to `expand_message_xmd`
+    using SHA-256.
   - HashToScalar(): Use hash_to_field from {{!I-D.irtf-cfrg-hash-to-curve}}
     using Order() as the prime modulus, with L=48, and expand_message_xmd with
     SHA-256.
@@ -936,9 +937,10 @@ and ristretto255. See {{cryptanalysis}} for related discussion.
 
 - Group: decaf448 {{!RISTRETTO}}
   - HashToGroup(): hash_to_decaf448
-    {{!I-D.irtf-cfrg-hash-to-curve}} with DST:
-    "VOPRF05-" || contextString, where `contextString` is that which is
-    computed in the Setup functions.
+    {{!I-D.irtf-cfrg-hash-to-curve}} with DST
+    "VOPRF05-" || `contextString`, where `contextString` is that which is
+    computed in the Setup functions, and `expand_message` set to `expand_message_xmd`
+    using SHA-512.
   - HashToScalar(): Use hash_to_field from {{!I-D.irtf-cfrg-hash-to-curve}}
     using Order() as the prime modulus, with L=84, and expand_message_xmd with
     SHA-512.
@@ -952,8 +954,8 @@ and ristretto255. See {{cryptanalysis}} for related discussion.
 
 - Group: P-256 (secp256r1) {{x9.62}}
   - HashToGroup(): P256_XMD:SHA-256_SSWU_RO\_
-    {{!I-D.irtf-cfrg-hash-to-curve}} with DST:
-    "VOPRF05-" || contextString, where `contextString` is that which is
+    {{!I-D.irtf-cfrg-hash-to-curve}} with DST
+    "VOPRF05-" || `contextString`, where `contextString` is that which is
     computed in the Setup functions.
   - HashToScalar(): Use hash_to_field from {{!I-D.irtf-cfrg-hash-to-curve}}
     using Order() as the prime modulus, with L=48, and expand_message_xmd with
@@ -967,8 +969,8 @@ and ristretto255. See {{cryptanalysis}} for related discussion.
 
 - Group: P-384 (secp384r1) {{x9.62}}
   - HashToGroup(): P384_XMD:SHA-512_SSWU_RO\_
-    {{!I-D.irtf-cfrg-hash-to-curve}} with DST:
-    "VOPRF05-" || contextString, where `contextString` is that which is
+    {{!I-D.irtf-cfrg-hash-to-curve}} with DST
+    "VOPRF05-" || `contextString`, where `contextString` is that which is
     computed in the Setup functions.
   - HashToScalar(): Use hash_to_field from {{!I-D.irtf-cfrg-hash-to-curve}}
     using Order() as the prime modulus, with L=72, and expand_message_xmd with
@@ -982,8 +984,8 @@ and ristretto255. See {{cryptanalysis}} for related discussion.
 
 - Group: P-521 (secp521r1) {{x9.62}}
   - HashToGroup(): P521_XMD:SHA-512_SSWU_RO\_
-    {{!I-D.irtf-cfrg-hash-to-curve}} with DST:
-    "VOPRF05-" || contextString, where `contextString` is that which is
+    {{!I-D.irtf-cfrg-hash-to-curve}} with DST
+    "VOPRF05-" || `contextString`, where `contextString` is that which is
     computed in the Setup functions.
   - HashToScalar(): Use hash_to_field from {{!I-D.irtf-cfrg-hash-to-curve}}
     using Order() as the prime modulus, with L=98, and expand_message_xmd with

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -954,7 +954,7 @@ and ristretto255. See {{cryptanalysis}} for related discussion.
 
 - Group: P-256 (secp256r1) {{x9.62}}
   - HashToGroup(): P256_XMD:SHA-256_SSWU_RO\_
-    {{!I-D.irtf-cfrg-hash-to-curve}} with DST
+    {{!I-D.irtf-cfrg-hash-to-curve}} with DST =
     "VOPRF05-" || `contextString`, where `contextString` is that which is
     computed in the Setup functions.
   - HashToScalar(): Use hash_to_field from {{!I-D.irtf-cfrg-hash-to-curve}}

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -969,7 +969,7 @@ and ristretto255. See {{cryptanalysis}} for related discussion.
 
 - Group: P-384 (secp384r1) {{x9.62}}
   - HashToGroup(): P384_XMD:SHA-512_SSWU_RO\_
-    {{!I-D.irtf-cfrg-hash-to-curve}} with DST
+    {{!I-D.irtf-cfrg-hash-to-curve}} with DST =
     "VOPRF05-" || `contextString`, where `contextString` is that which is
     computed in the Setup functions.
   - HashToScalar(): Use hash_to_field from {{!I-D.irtf-cfrg-hash-to-curve}}


### PR DESCRIPTION
This clarifies the change in #180.

cc @armfazh, @claucece 