### PR TITLE
Adding opaque-ke implementation as an integration to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ This requires that you have the necessary software installed.  See
 | [voprf-poc-go](https://github.com/alxdavids/voprf-poc/tree/master/go)     | Go       | draft-03 | All    |
 | [voprf-poc-rust](https://github.com/alxdavids/voprf-poc/tree/master/rust) | Rust     | draft-03 | All    |
 
+### Other Integrations
+
+| Implementation                                                            | Language | Version  | Modes  | Notes |
+| ------------------------------------------------------------------------- |:---------|:---------|:-------|:------|
+| [opaque-ke](https://github.com/novifinancial/opaque-ke/)                  | Rust     | draft-06 | Base   | As a component for OPAQUE |
+
 Submit a PR if you have a compliant implementation!
 
 ## Contributing


### PR DESCRIPTION
After discussion with @chris-wood :

Adding [opaque-ke](https://github.com/novifinancial/opaque-ke) as a Rust implementation of OPAQUE, which relies on VOPRF draft-06.

The VOPRF test vectors were copied [here](https://github.com/novifinancial/opaque-ke/blob/master/src/tests/voprf_test_vectors.rs) and checked for Ristretto255-SHA512, with support for more ciphersuite options coming in the future.

Note: I created a separate table for "integrations" because `opaque-ke` does not expose VOPRF in its high-level API -- it only uses VOPRF to perform OPAQUE operations, and hence other implementations cannot currently use `opaque-ke`'s VOPRF implementation. 