### PR TITLE
Updating CIRCL implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This requires that you have the necessary software installed.  See
 | ------------------------------------------------------------------------- |:---------|:---------|:-------|
 | [**Reference**](https://github.com/cfrg/draft-irtf-cfrg-voprf/tree/master/poc)        | Sage/Python | draft-06 | All |
 | [voprf](https://github.com/bytemare/voprf/)                               | Go       | draft-06 | All    |
-| [CIRCL](https://github.com/cloudflare/circl/)                             | Go       | draft-06 | All    |
+| [CIRCL](https://github.com/cloudflare/circl)                              | Go       | draft-07 | All    |
 | [BoringSSL](https://boringssl.googlesource.com/boringssl/+/refs/heads/master/crypto/trust_token/) | C       | draft-04 | All    |
 | [voprf-poc-go](https://github.com/alxdavids/voprf-poc/tree/master/go)     | Go       | draft-03 | All    |
 | [voprf-poc-rust](https://github.com/alxdavids/voprf-poc/tree/master/rust) | Rust     | draft-03 | All    |

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -45,6 +45,7 @@ author:
 normative:
   RFC2119:
   RFC7748:
+  RFC8446:
   PrivacyPass:
     title: Privacy Pass
     target: https://github.com/privacypass/challenge-bypass-server
@@ -408,7 +409,7 @@ The following conventions are used throughout the document.
   integer as described in {{!RFC8017}}. Note that these functions
   operate on byte arrays in big-endian byte order.
 
-Data structure descriptions use TLS notation {{?RFC8446, Section 3}}.
+Data structure descriptions use TLS notation {{RFC8446, Section 3}}.
 
 All algorithm descriptions are written in a Python-like pseudocode.
 We also use the `CT_EQUAL(a, b)` function to represent constant-time
@@ -1495,7 +1496,7 @@ This document resulted from the work of the Privacy Pass team
 {{PrivacyPass}}. The authors would also like to acknowledge helpful
 conversations with Hugo Krawczyk. Eli-Shaoul Khedouri provided
 additional review and comments on key consistency. Daniel Bourdrez,
-Tatiana Bradley, Sofía Celi, Frank Denis, and Bas Westerbaan also
+Tatiana Bradley, Sofia Celi, Frank Denis, and Bas Westerbaan also
 provided helpful input and contributions to the document.
 
 --- back
@@ -1529,8 +1530,8 @@ Test vectors with batch size B > 1 have inputs separated by a comma
 "Input", "Blind", "BlindedElement", "EvaluationElement", and
 "Output" fields.
 
-Base mode uses multiplicative blinding while verifiable mode 
-uses additive blinding, as described in {{base-client}} and 
+Base mode uses multiplicative blinding while verifiable mode
+uses additive blinding, as described in {{base-client}} and
 {{verifiable-client}}, respectively.
 
 The server key material, `pkSm` and `skSm`, are listed under the mode for

--- a/poc/test_oprf.sage
+++ b/poc/test_oprf.sage
@@ -96,7 +96,7 @@ class Protocol(object):
 
             outputs = client.finalize_batch(xs, blinds, evaluated_elements, blinded_elements, proof)
             for i, output in enumerate(outputs):
-                assert(server.verify_finalize(xs[i], output))
+                assert(server.verify_finalize(xs[i], output)) 
 
             vector = {}
             vector["Blind"] = ",".join([to_hex(group.serialize_scalar(blind)) for blind in blinds])


### PR DESCRIPTION
 - Make the file an ascii document.
 - Add RFC8446 to references.
 - CIRCL supports v07 [PR](https://github.com/cloudflare/circl/pull/241)