### PR TITLE
Make Blind fail earlier for the POPRF

### DIFF
--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -1075,7 +1075,7 @@ Output:
 
   opaque output[Nh]
 
-def Finalize(input, blind, evaluatedElement, blindedElement, proof, info, U):
+def Finalize(input, blind, evaluatedElement, blindedElement, proof, info, tweakedKey):
   if VerifyProof(G, tweakedKey, evaluatedElement, blindedElement, proof) == false:
     raise VerifyError
 

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -1000,6 +1000,7 @@ Output:
 
   Scalar blind
   Element blindedElement
+  Element tweakedKey
 
 Errors: InvalidInputError
 

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -986,7 +986,7 @@ def Finalize(input, blind, evaluatedElement, blindedElement, proof):
 The POPRF protocol begins with the client blinding its input, using the
 following modified `Blind` function. Note that this function can fail with an
 `InvalidInputError` error for certain private inputs that map to the group
-identity element, as well as certain public inputs that map lead to invalid
+identity element, as well as certain public inputs that map to invalid
 public keys for server evaluation. Dealing with either failure is an
 application-specific decision; see {{errors}}.
 

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -1022,7 +1022,7 @@ def Blind(input, info):
   return blind, blindedElement, tweakedKey
 ~~~
 
-Clients store the outputs `blind` and `U` locally and send `blindedElement` to
+Clients store the outputs `blind` and `tweakedKey` locally and send `blindedElement` to
 the server for evaluation. Upon receipt, servers process `blindedElement` to
 compute an evaluated element and DLEQ proof using the following `Evaluate` function.
 

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -1027,7 +1027,6 @@ the server for evaluation. Upon receipt, servers process `blindedElement` to
 compute an evaluated element and DLEQ proof using the following `Evaluate` function.
 
 ~~~
-Finalize
 
 Input:
 


### PR DESCRIPTION
Note that this check on the client is equivalent to the server, since `(skS + t) == 0` is only true iff `pkS + tG = skS*G + tG = (skS + t)G` is the identity element.

Closes #307.

cc @bytemare, @kevinlewi 