### PR TITLE
Include more details in DLEQ proof section.

### DIFF
--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -381,8 +381,8 @@ specific definitions of elliptic curves.
 A proof of knowledge allows a prover to convince a verifier that some
 statement is true. If the prover can generate a proof without interaction
 with the verifier, the proof is noninteractive. If the verifier learns
-nothing beyond the truthiness of the statement claimed by the prover,
-the proof is zero-knowledge.
+nothing other than whether the statement claimed by the prover is true or
+false, the proof is zero-knowledge.
 
 This section describes a noninteractive zero-knowledge proof for discrete
 logarithm equivalence (DLEQ). A DLEQ proof demonstrates that two pairs of

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -381,7 +381,7 @@ specific definitions of elliptic curves.
 A proof of knowledge allows a prover to convince a verifier that some
 statement is true. If the prover can generate a proof without interaction
 with the verifier, the proof is noninteractive. If the verifier learns
-nothing beyond that the veracity of the statement claimed by the prover,
+nothing beyond the truthiness of the statement claimed by the prover,
 the proof is zero-knowledge.
 
 This section describes a noninteractive zero-knowledge proof for discrete

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -55,7 +55,7 @@ informative:
     title: The Static Diffie-Hellman Problem
     target: https://eprint.iacr.org/2004/306
     date: false
-    authors:
+    author:
       -
         ins: D. Brown
         org: Certicom Research
@@ -68,9 +68,10 @@ informative:
     title: Efficient Zero-Knowledge Proofs and Applications
     target: http://hdl.handle.net/10012/8621
     date: false
-    authors:
+    author:
       -
         ins: R. Henry
+        name: Ryan Henry
         org: University of Waterloo, Ontario, Canada
   JKKX16: DOI.10.1109/EuroSP.2016.30
   JKK14: DOI.10.1007/978-3-662-45608-8_13
@@ -79,7 +80,7 @@ informative:
     title: A Fast and Simple Partially Oblivious PRF, with Applications
     target: https://eprint.iacr.org/2021/864
     date: false
-    authors:
+    author:
       -
         ins: N. Tyagi
         org: Cornell University, USA
@@ -384,13 +385,14 @@ nothing beyond that the veracity of the statement claimed by the prover,
 the proof is zero-knowledge.
 
 This section describes a noninteractive zero-knowledge proof for discrete
-logarithm equivalence (DLEQ). A DLEQ proof demonstrates that two pairs of group elements
-have the same discrete logarithm without revealing the discrete logarithm.
+logarithm equivalence (DLEQ). A DLEQ proof demonstrates that two pairs of
+group elements have the same discrete logarithm without revealing the
+discrete logarithm.
 
-
-The specific DLEQ proof construction presented below is built on the Chaum-Pedersen {{ChaumPedersen}}
-proof, which is proven to be zero-knowledge by Jarecki, et al. {{JKK14}} and
-can use batching techniques shown by Henry {{Hen14}}.
+The specific DLEQ proof construction presented below is built on the
+Chaum-Pedersen {{ChaumPedersen}} proof, which is proven to be zero-knowledge
+by Jarecki, et al. {{JKK14}} and use a product test batching technique
+described in Section 3.1.4 of {{Hen14}}.
 The description is split into
 two sub-sections: one for generating the proof, which is done by servers
 in the verifiable protocols, and another for verifying the proof, which is

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -391,7 +391,7 @@ discrete logarithm.
 
 The specific DLEQ proof construction presented below is built on the
 Chaum-Pedersen {{ChaumPedersen}} proof, which is proven to be zero-knowledge
-by Jarecki, et al. {{JKK14}} and use a product test batching technique
+by Jarecki, et al. {{JKK14}} and uses the product test batching technique
 described in Section 3.1.4 of {{Hen14}}.
 The description is split into
 two sub-sections: one for generating the proof, which is done by servers

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -322,7 +322,7 @@ to the repeated application of the group operation on the fixed group
 generator with itself `r-1` times, and is denoted as `ScalarBaseMult(r)`.
 Given two elements A and B, the discrete logarithm problem is to find
 an integer k such that B = k*A. Thus, k is the discrete logarithm of
-B to the base A.
+B with respect to the base A.
 The set of scalars corresponds to `GF(p)`, a prime field of order p, and are
 represented as the set of integers defined by `{0, 1, ..., p-1}`.
 This document uses types
@@ -383,16 +383,12 @@ with the verifier, the proof is noninteractive. If the verifier learns
 nothing beyond that the veracity of the statement claimed by the prover,
 the proof is zero-knowledge.
 
-This section describes a noninteractive zero-knowledge proof for the discrete
-logarithm equivalence (DLEQ), that is, proving that two pairs of group elements
-have the same discrete logarithm, but without revealing the discrete logarithm.
+This section describes a noninteractive zero-knowledge proof for discrete
+logarithm equivalence (DLEQ). A DLEQ proof demonstrates that two pairs of group elements
+have the same discrete logarithm without revealing the discrete logarithm.
 
-The DLEQ proof is an important piece to achieve verifiability of the OPRF
-protocols of this document. Due to the zero-knowledge property of the proof,
-the server can convince the client about the consistent use of the server's
-private key while the client learns nothing about its value.
 
-The proof presented below is built on the Chaum-Pedersen's {{ChaumPedersen}}
+The specific DLEQ proof construction presented below is built on the Chaum-Pedersen {{ChaumPedersen}}
 proof, which is proven to be zero-knowledge by Jarecki, et al. {{JKK14}} and
 can use batching techniques shown by Henry {{Hen14}}.
 The description is split into

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -64,6 +64,14 @@ informative:
         org: Certicom Research
   ChaumPedersen: DOI.10.1007/3-540-48071-4_7
   Cheon06: DOI.10.1007/11761679_1
+  Hen14:
+    title: Efficient Zero-Knowledge Proofs and Applications
+    target: http://hdl.handle.net/10012/8621
+    date: false
+    authors:
+      -
+        ins: R. Henry
+        org: University of Waterloo, Ontario, Canada
   JKKX16: DOI.10.1109/EuroSP.2016.30
   JKK14: DOI.10.1007/978-3-662-45608-8_13
   SJKS17: DOI.10.1109/ICDCS.2017.64
@@ -301,10 +309,7 @@ group `Group` for performing all mathematical operations. Such groups are
 uniquely determined by the choice of the prime `p` that defines the
 order of the group. (There may, however, exist different representations
 of the group for a single `p`. {{ciphersuites}} lists specific groups which
-indicate both order and representation.) We use `GF(p)` to represent the finite
-field of order `p`. For the purpose of understanding and implementing this
-document, we take `GF(p)` to be equal to the set of integers defined by
-`{0, 1, ..., p-1}`.
+indicate both order and representation.)
 
 The fundamental group operation is addition `+` with identity element
 `I`. For any elements `A` and `B` of the group, `A + B = B + A` is
@@ -315,7 +320,12 @@ element A with itself `r-1` times, this is denoted as `r*A = A + ... + A`.
 For any element `A`, `p*A=I`. Scalar base multiplication is equivalent
 to the repeated application of the group operation on the fixed group
 generator with itself `r-1` times, and is denoted as `ScalarBaseMult(r)`.
-The set of scalars corresponds to `GF(p)`. This document uses types
+Given two elements A and B, the discrete logarithm problem is to find
+an integer k such that B = k*A. Thus, k is the discrete logarithm of
+B to the base A.
+The set of scalars corresponds to `GF(p)`, a prime field of order p, and are
+represented as the set of integers defined by `{0, 1, ..., p-1}`.
+This document uses types
 `Element` and `Scalar` to denote elements of the group and its set of
 scalars, respectively.
 
@@ -365,14 +375,27 @@ with a prime-order group instantiation are removed. See {{ciphersuites}}
 for advice corresponding to the implementation of this interface for
 specific definitions of elliptic curves.
 
-## Discrete Log Equivalence Proofs {#dleq}
+## Discrete Logarithm Equivalence Proofs {#dleq}
 
-Another important piece of the OPRF protocols in this document is proving
-that the discrete log of two values is identical in zero knowledge, i.e.,
-without revealing the discrete logarithm. This is referred to as a discrete
-log equivalence (DLEQ) proof. This section describes functions
-for non-interactively proving and verifying this type of statement,
-built on a Chaum-Pedersen {{ChaumPedersen}} proof. It is split into
+A proof of knowledge allows a prover to convince a verifier that some
+statement is true. If the prover can generate a proof without interaction
+with the verifier, the proof is noninteractive. If the verifier learns
+nothing beyond that the veracity of the statement claimed by the prover,
+the proof is zero-knowledge.
+
+This section describes a noninteractive zero-knowledge proof for the discrete
+logarithm equivalence (DLEQ), that is, proving that two pairs of group elements
+have the same discrete logarithm, but without revealing the discrete logarithm.
+
+The DLEQ proof is an important piece to achieve verifiability of the OPRF
+protocols of this document. Due to the zero-knowledge property of the proof,
+the server can convince the client about the consistent use of the server's
+private key while the client learns nothing about its value.
+
+The proof presented below is built on the Chaum-Pedersen's {{ChaumPedersen}}
+proof, which is proven to be zero-knowledge by Jarecki, et al. {{JKK14}} and
+can use batching techniques shown by Henry {{Hen14}}.
+The description is split into
 two sub-sections: one for generating the proof, which is done by servers
 in the verifiable protocols, and another for verifying the proof, which is
 done by clients in the protocol.


### PR DESCRIPTION
It addresses the following items from [review](https://mailarchive.ietf.org/arch/msg/crypto-panel/QXC3drh1hs-XGkXyjwyCj_pFNNI/)

>   2.  2.2 on page 10 says "... proving that the discrete log of two values is identical in zero knowledge" without ever defining discrete log and zero knowledge proofs. The authors say that their construction is built on Chaum-Pedersen proof, but no further details are provided.
>   4.  2.2.1 on page 11 ends the description of GenerateProof without ever describing why the output of the function [c , s] is a discrete log equivalence proof and why is it zero knowledge.
>   5.  2.1 on page 8 starts talking about groups and then suddenly mentions finite fields without explaining what they are. It becomes clear reading further down that the authors need them for scalars. It would have been less confusing if they simply used the set of integers {0, 1, ..., p-1}.

