### PR TITLE
Addresses some comments by JH

### DIFF
--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -1456,7 +1456,7 @@ admit public input.
 This section discusses the cryptographic security of our protocol, along
 with some suggestions and trade-offs that arise from the implementation
 of the OPRF variants in this document. Note that the syntax of the POPRF
-variant is different from that of the OPRF and POPRF variants since it
+variant is different from that of the OPRF and VOPRF variants since it
 admits an additional public input, but the same security considerations apply.
 
 ## Security Properties {#properties}
@@ -1464,9 +1464,9 @@ admits an additional public input, but the same security considerations apply.
 The security properties of an OPRF protocol with functionality y = F(k, x)
 include those of a standard PRF. Specifically:
 
-- Pseudorandomness: F is pseudorandom if the output y = F(k, x) on any
-  input x is indistinguishable from uniformly sampling any element in
-  F's range, for a random sampling of k.
+- Pseudorandomness: For a random sampling of k, F is pseudorandom if the output
+  y = F(k, x) on any input x is indistinguishable from uniformly sampling any
+  element in F's range.
 
 In other words, consider an adversary that picks inputs x from the
 domain of F and evaluates F on (k, x) (without knowledge of randomly
@@ -1483,10 +1483,11 @@ be non-malleable to maintain indistinguishability.
 - Unconditional input secrecy: The server does not learn anything about
   the client input x, even with unbounded computation.
 
-In other words, an attacker with infinite compute cannot recover any information
-about the client's private input x from an invocation of the protocol.
+In other words, an attacker with infinite computing power cannot recover any
+information about the client's private input x from an invocation of the
+protocol.
 
-Additionally, for the VOPRF and POPRF protocol variants, there is an additional
+For the VOPRF and POPRF protocol variants, there is an additional
 security property:
 
 - Verifiable: The client must only complete execution of the protocol if
@@ -1527,12 +1528,14 @@ that this document supports batching so that multiple evaluations can happen
 at once whilst only constructing one DLEQ proof object. This is enabled using
 an established batching technique {{DGSTV18}}.
 
-The pseudorandomness and input secrecy (and verifiability) of the OPRF (and VOPRF) variants
-is based on the assumption that the One-More Gap Computational Diffie Hellman (CDH) is computationally
-difficult to solve in the corresponding prime-order group. The original paper {{JKK14}}
-gives a security proof that the construction satisfies the security guarantees of a
-VOPRF protocol {{properties}} under the One-More Gap CDH assumption in the universal
-composability (UC) security framework.
+The pseudorandomness and input secrecy (and verifiability) of the OPRF (and
+VOPRF) variant is based on an assumption with oracle access to the
+Computational Diffie Hellman (CDH) assumption, known as the One-More Gap CDH,
+that is computationally difficult to solve in the corresponding prime-order
+group. The original paper {{JKK14}} gives a security proof that the
+construction satisfies the security guarantees of a VOPRF protocol
+(as in {{properties}}) under the One-More Gap CDH assumption in the
+universal composability (UC) security framework.
 
 ### POPRF Assumptions
 

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -1244,11 +1244,12 @@ See {{cryptanalysis}} for related discussion.
     using SHA-512.
   - HashToScalar(): Compute `uniform_bytes` using `expand_message` = `expand_message_xmd`,
     DST = "HashToScalar-" || contextString, and output length 64, interpret
-    `uniform_bytes` as a 512-bit integer in little-endian order, and reduce the integer
-    modulo `Order()`.
+    `uniform_bytes` as a 512-bit integer in little-endian order, and reduce the
+    integer modulo `Group.Order()`.
   - Serialization: Both group elements and scalars are encoded in Ne = Ns = 32
     bytes. For group elements, use the 'Encode' and 'Decode' functions from
-    {{!RISTRETTO}}. For scalars, ensure they are fully reduced modulo `Order()`
+    {{!RISTRETTO}}. For scalars, ensure they are fully reduced modulo
+    `Group.Order()`
     and in little-endian order.
 - Hash: SHA-512, and Nh = 64.
 - ID: 0x0001
@@ -1262,11 +1263,12 @@ See {{cryptanalysis}} for related discussion.
     using SHAKE-256.
   - HashToScalar(): Compute `uniform_bytes` using `expand_message` = `expand_message_xof`,
     DST = "HashToScalar-" || contextString, and output length 64, interpret
-    `uniform_bytes` as a 512-bit integer in little-endian order, and reduce the integer
-    modulo `Order()`.
+    `uniform_bytes` as a 512-bit integer in little-endian order, and reduce the
+    integer modulo `Group.Order()`.
   - Serialization: Both group elements and scalars are encoded in Ne = Ns = 56
     bytes. For group elements, use the 'Encode' and 'Decode' functions from
-    {{!RISTRETTO}}. For scalars, ensure they are fully reduced modulo `Order()`
+    {{!RISTRETTO}}. For scalars, ensure they are fully reduced modulo
+    `Group.Order()`
     and in little-endian order.
 - Hash: SHAKE-256, and Nh = 64.
 - ID: 0x0002
@@ -1280,11 +1282,11 @@ See {{cryptanalysis}} for related discussion.
   - HashToScalar(): Use hash_to_field from {{!I-D.irtf-cfrg-hash-to-curve}}
     using L = 48, `expand_message_xmd` with SHA-256,
     DST = "HashToScalar-" || contextString, and
-    prime modulus equal to `Order()`.
+    prime modulus equal to `Group.Order()`.
   - Serialization: Elements are serialized as Ne = 33 byte strings using
     compressed point encoding for the curve {{SEC1}}. Scalars are serialized as
-    Ns = 32 byte strings by fully reducing the value modulo `Order()` and in big-endian
-    order.
+    Ns = 32 byte strings by fully reducing the value modulo `Group.Order()` and
+    in big-endian order.
 - Hash: SHA-256, and Nh = 32.
 - ID: 0x0003
 
@@ -1297,11 +1299,11 @@ See {{cryptanalysis}} for related discussion.
   - HashToScalar(): Use hash_to_field from {{!I-D.irtf-cfrg-hash-to-curve}}
     using L = 72, `expand_message_xmd` with SHA-384,
     DST = "HashToScalar-" || contextString, and
-    prime modulus equal to `Order()`.
+    prime modulus equal to `Group.Order()`.
   - Serialization: Elements are serialized as Ne = 49 byte strings using
     compressed point encoding for the curve {{SEC1}}. Scalars are serialized as
-    Ns = 48 byte strings by fully reducing the value modulo `Order()` and in big-endian
-    order.
+    Ns = 48 byte strings by fully reducing the value modulo `Group.Order()` and
+    in big-endian order.
 - Hash: SHA-384, and Nh = 48.
 - ID: 0x0004
 
@@ -1314,11 +1316,11 @@ See {{cryptanalysis}} for related discussion.
   - HashToScalar(): Use hash_to_field from {{!I-D.irtf-cfrg-hash-to-curve}}
     using L = 98, `expand_message_xmd` with SHA-512,
     DST = "HashToScalar-" || contextString, and
-    prime modulus equal to `Order()`.
+    prime modulus equal to `Group.Order()`.
   - Serialization: Elements are serialized as Ne = 67 byte strings using
     compressed point encoding for the curve {{SEC1}}. Scalars are serialized as
-    Ns = 66 byte strings by fully reducing the value modulo `Order()` and in big-endian
-    order.
+    Ns = 66 byte strings by fully reducing the value modulo `Group.Order()` and
+    in big-endian order.
 - Hash: SHA-512, and Nh = 64.
 - ID: 0x0005
 
@@ -1358,9 +1360,10 @@ byte array. Like DeserializeElement, this function validates that the element
 is a member of the scalar field and returns an error if this condition is not met.
 
 For P-256, P-384, and P-521 ciphersuites, this function ensures that the input,
-when treated as a big-endian integer, is a value between 0 and `Order() - 1`. For
+when treated as a big-endian integer, is a value between 0 and
+`Group.Order() - 1`. For
 ristretto255 and decaf448, this function ensures that the input, when treated as
-a little-endian integer, is a value between 0 and `Order() - 1`.
+a little-endian integer, is a value between 0 and `Group.Order() - 1`.
 
 ## Future Ciphersuites
 

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -726,12 +726,10 @@ def CreateContextString(mode, suiteID):
 
 ## Key Generation and Context Setup {#offline}
 
-In the offline setup phase, both the client and server create a context used
-for executing the online phase of the protocol after agreeing on a mode and
-ciphersuite value suiteID. The server key pair (`skS`, `pkS`) is generated
+In the offline setup phase, the server key pair (`skS`, `pkS`) is generated
 using the following function, which accepts a randomly generated seed of length
-`Ns` and optional public `info` string. The constant `Ns` corresponds to the
-size of a serialized Scalar and is defined in {{pog}}.
+`Ns` bytes and optional public `info` string. The constant `Ns` corresponds to
+the size in bytes of a serialized Scalar and is defined in {{pog}}.
 
 ~~~
 Input:
@@ -765,6 +763,12 @@ def DeriveKeyPair(seed, info):
   pkS = G.ScalarMultGen(skS)
   return skS, pkS
 ~~~
+
+Also during the offline setup phase, both the client and server create a
+context used for executing the online phase of the protocol after agreeing on a
+mode and ciphersuite value `suiteID`. The context, such as `OPRFServerContext`,
+is an implementation-specific data structure that stores a context string and
+the relevant key material for each party.
 
 The OPRF variant server and client contexts are created as follows:
 

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -421,7 +421,7 @@ done by clients in the protocol.
 Generating a proof is done with the `GenerateProof` function, defined below.
 Given elements A and B, two non-empty lists of elements C and D of length
 `m`, and a scalar k; this function produces a proof that `k*A == B`
-and `k*C[i] == D[i]` for each element in the list.
+and `k*C[i] == D[i]` for each `i` in `[0, ..., m - 1]`.
 The output is a value of type Proof, which is a tuple of two Scalar
 values.
 

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -168,7 +168,7 @@ OPRFs have a variety of applications, including: password-protected secret
 sharing schemes {{JKKX16}}, privacy-preserving password stores {{SJKS17}}, and
 password-authenticated key exchange or PAKE {{!I-D.irtf-cfrg-opaque}}.
 Verifiable POPRFs are necessary in some applications such as Privacy Pass
-{{!I-D.ietf-privacypass-protocol}}. Verifiable POPRFs have also been used for
+{{!I-D.ietf-privacypass-protocol}}. Verifiable OPRFs have also been used for
 password-protected secret sharing schemes such as that of {{JKK14}}.
 
 This document specifies OPRF, VOPRF, and POPRF protocols built upon

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -362,13 +362,13 @@ prime-order group.
   non-zero element in GF(p).
 - ScalarInverse(s): Returns the inverse of input Scalar `s` on `GF(p)`.
 - SerializeElement(A): A member function of `Group` that maps a group element
-  `A` to a unique byte array `buf` of fixed length `Ne`.
+  `A` to a unique byte array `buf` of fixed length `Ne` bytes.
 - DeserializeElement(buf): A member function of `Group` that maps a byte
   array `buf` to a group element `A`, or raise a DeserializeError if the
   input is not a valid byte representation of an element.
   See {{input-validation}} for further requirements on input validation.
 - SerializeScalar(s): A member function of `Group` that maps a scalar element
-  `s` to a unique byte array `buf` of fixed length `Ns`.
+  `s` to a unique byte array `buf` of fixed length `Ns` bytes.
 - DeserializeScalar(buf): A member function of `Group` that maps a byte
   array `buf` to a scalar `s`, or raise a DeserializeError if the input
   is not a valid byte representation of a scalar.
@@ -1255,7 +1255,7 @@ See {{cryptanalysis}} for related discussion.
     {{!RISTRETTO}}. For scalars, ensure they are fully reduced modulo
     `Group.Order()`
     and in little-endian order.
-- Hash: SHA-512, and Nh = 64.
+- Hash: SHA-512, and Nh = 64 bytes.
 - ID: 0x0001
 
 ### OPRF(decaf448, SHAKE-256)
@@ -1274,7 +1274,7 @@ See {{cryptanalysis}} for related discussion.
     {{!RISTRETTO}}. For scalars, ensure they are fully reduced modulo
     `Group.Order()`
     and in little-endian order.
-- Hash: SHAKE-256, and Nh = 64.
+- Hash: SHAKE-256, and Nh = 64 bytes.
 - ID: 0x0002
 
 ### OPRF(P-256, SHA-256)
@@ -1291,7 +1291,7 @@ See {{cryptanalysis}} for related discussion.
     compressed point encoding for the curve {{SEC1}}. Scalars are serialized as
     Ns = 32 byte strings by fully reducing the value modulo `Group.Order()` and
     in big-endian order.
-- Hash: SHA-256, and Nh = 32.
+- Hash: SHA-256, and Nh = 32 bytes.
 - ID: 0x0003
 
 ### OPRF(P-384, SHA-384)
@@ -1308,7 +1308,7 @@ See {{cryptanalysis}} for related discussion.
     compressed point encoding for the curve {{SEC1}}. Scalars are serialized as
     Ns = 48 byte strings by fully reducing the value modulo `Group.Order()` and
     in big-endian order.
-- Hash: SHA-384, and Nh = 48.
+- Hash: SHA-384, and Nh = 48 bytes.
 - ID: 0x0004
 
 ### OPRF(P-521, SHA-512)
@@ -1325,7 +1325,7 @@ See {{cryptanalysis}} for related discussion.
     compressed point encoding for the curve {{SEC1}}. Scalars are serialized as
     Ns = 66 byte strings by fully reducing the value modulo `Group.Order()` and
     in big-endian order.
-- Hash: SHA-512, and Nh = 64.
+- Hash: SHA-512, and Nh = 64 bytes.
 - ID: 0x0005
 
 ## Input Validation {#input-validation}


### PR DESCRIPTION
Addresses some of the comments by JH [posted here](https://mailarchive.ietf.org/arch/msg/cfrg/rHVKNpdHx8jWhwqpvlvEKV4pm-4/).

The best way to review this PR is going commit by commit.
I am confident of all of them except of the last one related to naming the assumptions.

## Addressed in this PR
 
> - The introduction mentions POPRFs have been used for PPSS in JKK14, but 
that paper uses only VOPRFs explicitly and I cannot spot implicit use of 
a partially oblivious protocol in their PPSS construction.

> - The document uses both "base point" and "group generator". Maybe unify?

> - Member functions of the group are sometimes referred to as 
Group.function() and sometimes just as function(). Some of the 
appearances, e.g., of Order() in 4.1.4, do appear in the context of a 
group Group, so the write-up could be clarified by putting Group.Order() 
instead.

> - First paragraph of 2.2.1 "k*C[i]==D[i] for each element in the list." 
Better "for each i in {1,...,m}".

> - The terms (functions?) OPRFServerContext, VOPRFClientContext etc. do 
not seem to be defined.

> - Section 4.1.1 and following: some numbers are missing "bytes", e.g., 
the Nh values, L = 48,...

> - Section 6, first paragraph, has one POPRF that should be VOPRF

> - 6.1 Pseudorandomness: pull "for a random sampling of k" to the first 
part of the sentence.

> - "with infinite compute" - infinite computing power?

> - "Additionally, for the.... additional" - remove the first one?

> - "One-More Gap Computational Diffie Hellman (CDH)" This is not what CDH 
usually stands for.

> - "variant is based on" - are based on?


## Not addressed


> - "Verifiable POPRF": the verifiability property is not optional in the 
draft, but the fact that it is sometimes called "verifiable POPRF" hints 
that it is. Why not avoid any confusion by calling it VPOPRF throughout 
the document?

> - Section 1.3 introduces PrivateInput and PublicInput as the exact same 
data types. What distinguishes them? The terms Private and Public hint 
at something, but it seems never spelled out in the document.

> - In general the distinction between "Input" and "Parameters" in the 
function descriptions confused me. What are the semantics here? First I 
thought Parameters are implementation-wide and fixed objects, like the 
Group, but then the OPRF key skS appears as a Parameter of 
BlindEvaluate. Since the document also hints that keys can be updated 
during the run of the protocol ("key rotation"), skS does not seem to be 
a long-term parameter to me. Sometimes both the terms Input and 
Parameter are  mixed, for example when "PublicInput contextString" 
appears under Parameters. Another example is in the flow diagram of 
POPRF, where both Inputs (info) and Parameters (pkS,skS) appear in 
parantheses after a party's name.
Overall it would be good to clarify why the function descriptions 
distinguish between "Inputs" and "Parameters", as otherwise implementors 
might interpret their own meaning to these terms.


> - Explain the list notation []

> - Section 3, protocol overviews: skS and pkS appear as input to the 
parties but are not used in the protocols. E.g., it should be 
BlindEvaluate(skS,blindedElement) instead of BlindEvaluate(blindedElement).

> - Still protocol overviews: I find the term "evaluatedElement" computed 
by the server a bit misleading, as it sounds like the server is learning 
the evaluation. On the other hand I don't have a better idea. 
BlindedEvaluatedElement would indicate more precisely what happens, but 
is probably too long.

> - "client and server augment the pkS and skS, respectively, using the 
info value": this could be modified to explain the (otherwise 
unexplained) "tweakedKey" term that appears in the protocol overview. 
Maybe "client and server tweak their pkS and skS, respectively, using 
the info value"?

> - *If* I would implement this, I would wonder about Input "opaque 
seed[Ns]". Ns is an integer, and this seed appears to be a list of Ns 
opaque values. In the text it says "randomly generated seed". The seeds 
suggested in the test vector section do not appear very random to me ;) 
Not sure if this is underspecified or just common knowledge.

> - "Recall that servers may batch multiple client inputs to 
BlindEvaluate." - Maybe one more sentence how this is done? Just 
repeated execution of BlindEvaluate and concatenating the 
evaluatedElements in the message to the client?

> - "certain public inputs that map to invalid public keys for server 
evaluation." I could not parse "public key for server evaluation" here.

> - I could not make any sense of 5.2, but again, not an implementor...


> - Partial obliviousness: I don't understand this definition. Everything 
but the last sentence are properties of any OPRF, as described already 
in the other properties. The sentence "Both client and server learn the 
public input (info)" does not seem to have any meaning, since info is 
*input* to both parties and hence they of course learn it. The partial 
obliviousness property rather seems to enforce usage of info in an 
evaluation.
I was also surprised that partial obliviousness is equivalent to 
unlinkability. Are OPRFs linkable, in the sense of linkability described 
in the draft?

> - Risking a few hits on my head: JKK14 does *not* give a security proof 
for the VOPRF protocol in Section 6.1. JKK14 requires session 
identifiers and is in the random oracle model. Unless, e.g., hash domain 
separation is put as a MUST in the draft, the analysis of JKK14 does not 
apply to the protocol in Section 6.1.

> - In reference [SJKS17] typos in Jareckiy, Krawczykz