### PR TITLE
Warning during BlindEvaluate for POPRF.

### DIFF
--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -1090,10 +1090,12 @@ In the description above, inputs to `GenerateProof` are one-item
 lists. Using larger lists allows servers to batch the evaluation of multiple
 elements while producing a single batched DLEQ proof for them.
 
-When `BlindEvaluate` triggers `InverseError` means the function is about to
-calculate the inverse of a zero scalar, which is a failure of the protocol.
+`BlindEvaluate` triggers `InverseError` when the function is about to
+calculate the inverse of a zero scalar, which does not exist and therefore
+yields a failure in the protocol.
 More importantly, it also means there exists an input `info` that maps to the
-secret key of the server, and this may be known by a malicious client. Hence,
+secret key of the server. Clients that observe this signal are assumed to therefore
+know the server secret key. Hence,
 this error can be a signal for the server to replace its secret key.
 
 The server sends both `evaluatedElement` and `proof` back to the client.

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -436,7 +436,7 @@ def GenerateProof(k, A, B, C, D)
             "Challenge"
 
   c = G.HashToScalar(h2Input)
-  s = (r - c * k) mod G.Order()
+  s = r - c * k
 
   return [c, s]
 ~~~
@@ -1089,6 +1089,12 @@ def BlindEvaluate(blindedElement, info):
 In the description above, inputs to `GenerateProof` are one-item
 lists. Using larger lists allows servers to batch the evaluation of multiple
 elements while producing a single batched DLEQ proof for them.
+
+When `BlindEvaluate` triggers `InverseError` means the function is about to
+calculate the inverse of a zero scalar, which is a failure of the protocol.
+More importantly, it also means there exists an input `info` that maps to the
+secret key of the server, and this may be known by a malicious client. Hence,
+this error can be a signal for the server to replace its secret key.
 
 The server sends both `evaluatedElement` and `proof` back to the client.
 Upon receipt, the client processes both values to complete the POPRF computation

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -1093,9 +1093,8 @@ elements while producing a single batched DLEQ proof for them.
 `BlindEvaluate` triggers `InverseError` when the function is about to
 calculate the inverse of a zero scalar, which does not exist and therefore
 yields a failure in the protocol.
-More importantly, it also means there exists an input `info` that maps to the
-secret key of the server. Clients that observe this signal are assumed to therefore
-know the server secret key. Hence,
+This only occurs for `info` values that map to the secret key of the server. Thus, 
+clients that observe this signal are assumed to know the server secret key. Hence,
 this error can be a signal for the server to replace its secret key.
 
 The server sends both `evaluatedElement` and `proof` back to the client.


### PR DESCRIPTION
Addresses the comments by NG posted [in the list](https://mailarchive.ietf.org/arch/msg/cfrg/P4F00i3DbQR2KkHQ0Sl2E-i-D2E/)


> pg. 11 In definition of GenerateProof appears the only use of the mod operator on scalars (it is used elsewhere on integers):
> 
> 			s = (r - c*k) mod G.order().
> To be consistent, consider replacing with s = (r - c*k) as scalars lie in GF(p).  

> pg. 24. 3.3.3, raise InverseError when skS + m = 0.
> While it is common practice to return an error message, here the server learns that the key skS is leaked as m is known externally.  Given that this is being checked, perhaps add a warning that it may be time to rekey.



> The proof batching via ComputeCompositesFast requires 3 + i scalar multiplications to generate a proof for a batch of size i.  It's fairly complicated and spans over 4 pages.  However, the "basic scheme" in [ChaumPedersen] requires 2 such multiplications for a single proof, and is simple/intuitive.  Given that, I think it makes sense to include it in the draft and perhaps move the  batching method to an annex as an option.  (FWIW I did spend a few cycles looking at the batching proof and the steps taken do seem necessary).  

**Comment:** The original proof by Chaum-Pedersen takes 2*N multiplications to process N instances of the proof. The batched proof in VOPRF document takes N+3 multiplications.
This means that the batched method has more advantage when:

$$ 
\begin{array}%
2 N \geq N+3 \\
  N \geq 3 \\
\end{array}
$$

Thus, the cases N=1,2 could be subpar, but it is expected that applications relying on batched VOPRFs benefit from this method.

