### PR TITLE
Addresses comments by RH

### DIFF
--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -377,7 +377,7 @@ number of inputs.
 The specific DLEQ proof system presented below follows this latter
 construction with two modifications: (1) the transcript used to generate
 the seed includes more context information, and (2) the individual challenges
-for each element in the proof is derived from a seed-prefixed hash-to-scalar
+for each proof are derived from a seed-prefixed hash-to-scalar
 invocation rather than being sampled from a seeded PRNG.
 The description is split into
 two sub-sections: one for generating the proof, which is done by servers

--- a/poc/oprf.sage
+++ b/poc/oprf.sage
@@ -446,7 +446,7 @@ ciphersuite_p521_sha512 = 0x0005
 
 oprf_ciphersuites = {
     ciphersuite_ristretto255_sha512: Ciphersuite("OPRF(ristretto255, SHA-512)", ciphersuite_ristretto255_sha512, GroupRistretto255(), hashlib.sha512, lambda x : hashlib.sha512(x).digest()),
-    ciphersuite_decaf448_shake256: Ciphersuite("OPRF(decaf448, SHAKE-256)", ciphersuite_decaf448_shake256, GroupDecaf448(), hashlib.shake_256, lambda x : hashlib.shake_256(x).digest(int(64))),
+    ciphersuite_decaf448_shake256: Ciphersuite("OPRF(decaf448, SHAKE256)", ciphersuite_decaf448_shake256, GroupDecaf448(), hashlib.shake_256, lambda x : hashlib.shake_256(x).digest(int(64))),
     ciphersuite_p256_sha256: Ciphersuite("OPRF(P-256, SHA-256)", ciphersuite_p256_sha256, GroupP256(), hashlib.sha256, lambda x : hashlib.sha256(x).digest()),
     ciphersuite_p384_sha384: Ciphersuite("OPRF(P-384, SHA-384)", ciphersuite_p384_sha384, GroupP384(), hashlib.sha384, lambda x : hashlib.sha384(x).digest()),
     ciphersuite_p521_sha512: Ciphersuite("OPRF(P-521, SHA-512)", ciphersuite_p521_sha512, GroupP521(), hashlib.sha512, lambda x : hashlib.sha512(x).digest()),


### PR DESCRIPTION
Addresses comments by RH.


> Section 2.1 says: "... each element in the proof ...".  In the previous
sentence, there is a discussion of "batching DLEQ proofs".  I think
this is talking about each proof in the batch.  Please clarify.

> Section 6.1: Please consider definitions for domain and range.
The definitions probably go in Section 1.3, nit in this section.

**Comment:** I think the description is abstract, and there is no need to define these terms.

> Nits:
>
> The document uses "byte array" and "byte string".  I think it would be
helpful to pick one and use it throughout.  (I have a mild preference
for byte string because it makes it easier to define "ASCII string
literals".)

> Throughout the document: s/SHAKE-256/SHAKE256/

> The curves referenced in [X9.62] are also available in [SEC2], which is
already being referenced.  I think you can get away with one less
reference.

**Comment:** Still using X9.62 as appeared before than SEC2.

> Section 3.1: s/a one-byte value/a one-byte value (in hexadecimal)/

> Section 3.2: s/optional public/an optional public/

> Section 5.3: s/specification, however/specification; however,/

> Section 6.2.1 says: "... VOPRF protocol Section 6.1 ...".  There seem
to be some words missing.  I think this is trying to say: "... VOPRF
protocol specified in Section 6.1 of this document ...".

> Suggestion:
> 
> Once the change log is removed by the RFC Editor, the rationale for
having both ComputeComposites and ComputeCompositesFast will be lost.
Please add some text to the body of the document to capture this
detail.
