### PR TITLE
Make ciphersuite function implementation explicit (including input validation)

### DIFF
--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -1347,7 +1347,7 @@ See {{cryptanalysis}} for related discussion.
   - ScalarInverse(s): Returns the multipicative inverse of input Scalar `s` mod `Group.Order()`.
   - SerializeElement(A): Implemented using the compressed Elliptic-Curve-Point-to-Octet-String
     method according to {{SEC1}}; Ne = 49.
-  - DeserializeElement(buf): Implemented by attempting to deserialize a 49 byte input string to
+  - DeserializeElement(buf): Implemented by attempting to deserialize a 49-byte array  to
     a public key using the compressed Octet-String-to-Elliptic-Curve-Point method according to {{SEC1}},
     and then performs partial public-key validation as defined in section 5.6.2.3.4 of
     {{!KEYAGREEMENT=DOI.10.6028/NIST.SP.800-56Ar3}}. This includes checking that the

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -1251,7 +1251,7 @@ See {{cryptanalysis}} for related discussion.
     DST = "HashToScalar-" || contextString, and output length 64, interpret
     `uniform_bytes` as a 512-bit integer in little-endian order, and reduce the
     integer modulo `Group.Order()`.
-  - ScalarInverse(s): Returns the multipicative inverse of input Scalar `s` mod `Group.Order()`.
+  - ScalarInverse(s): Returns the multiplicative inverse of input Scalar `s` mod `Group.Order()`.
   - RandomScalar(): Implemented by returning a uniformly random Scalar in the range
     \[0, `G.Order()` - 1\]. Refer to {{random-scalar}} for implementation guidance.
   - SerializeElement(A): Implemented using the 'Encode' function from Section 4.3.2 of {{!RISTRETTO}}; Ne = 32.
@@ -1311,7 +1311,7 @@ See {{cryptanalysis}} for related discussion.
     using L = 48, `expand_message_xmd` with SHA-256,
     DST = "HashToScalar-" || contextString, and
     prime modulus equal to `Group.Order()`.
-  - ScalarInverse(s): Returns the multipicative inverse of input Scalar `s` mod `Group.Order()`.
+  - ScalarInverse(s): Returns the multiplicative inverse of input Scalar `s` mod `Group.Order()`.
   - SerializeElement(A): Implemented using the compressed Elliptic-Curve-Point-to-Octet-String
     method according to {{SEC1}};  Ne = 33.
   - DeserializeElement(buf): Implemented by attempting to deserialize a 33 byte input string to
@@ -1344,7 +1344,7 @@ See {{cryptanalysis}} for related discussion.
     using L = 72, `expand_message_xmd` with SHA-384,
     DST = "HashToScalar-" || contextString, and
     prime modulus equal to `Group.Order()`.
-  - ScalarInverse(s): Returns the multipicative inverse of input Scalar `s` mod `Group.Order()`.
+  - ScalarInverse(s): Returns the multiplicative inverse of input Scalar `s` mod `Group.Order()`.
   - SerializeElement(A): Implemented using the compressed Elliptic-Curve-Point-to-Octet-String
     method according to {{SEC1}}; Ne = 49.
   - DeserializeElement(buf): Implemented by attempting to deserialize a 49-byte array  to
@@ -1378,7 +1378,7 @@ See {{cryptanalysis}} for related discussion.
     using L = 98, `expand_message_xmd` with SHA-512,
     DST = "HashToScalar-" || contextString, and
     prime modulus equal to `Group.Order()`.
-  - ScalarInverse(s): Returns the multipicative inverse of input Scalar `s` mod `Group.Order()`.
+  - ScalarInverse(s): Returns the multiplicative inverse of input Scalar `s` mod `Group.Order()`.
   - SerializeElement(A): Implemented using the compressed Elliptic-Curve-Point-to-Octet-String
     method according to {{SEC1}}; Ne = 67.
   - DeserializeElement(buf): Implemented by attempting to deserialize a 49 byte input string to

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -1319,8 +1319,7 @@ See {{cryptanalysis}} for related discussion.
     and then performs partial public-key validation as defined in section 5.6.2.3.4 of
     {{!KEYAGREEMENT=DOI.10.6028/NIST.SP.800-56Ar3}}. This includes checking that the
     coordinates of the resulting point are in the correct range, that the point is on
-    the curve, and that the point is not the point at infinity. Additionally, this function
-    validates that the resulting element is not the group identity element.
+    the curve, and that the point is not the group identity element.
     If these checks fail, deserialization returns an InputValidationError error.
   - SerializeScalar(s): Implemented using the Field-Element-to-Octet-String conversion
     according to {{SEC1}}; Ns = 32.

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -1446,7 +1446,7 @@ most b bits.
 
 Generate a random byte array with `l = ceil(((3 * ceil(log2(G.Order()))) / 2) / 8)`
 bytes, and interpret it as an integer; reduce the integer modulo `G.Order()` and return the
-result. See {{Section 5 of HASH-TO-CURVE}} for the underlying derivation of `l`.
+result. See {{I-D.irtf-cfrg-hash-to-curve, Section 5}} for the underlying derivation of `l`.
 
 # Application Considerations {#apis}
 

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -1441,7 +1441,7 @@ such that `p - 2<sup>b</sup>| < 2<sup>(b/2)</sup>`, then
 `RandomScalar` can simply return a uniformly random integer of at
 most b bits.
 
-### Wide Reduction
+### Random Number Generation Using Extra Random Bits
 
 Generate a random byte array with `l = ceil(((3 * ceil(log2(G.Order()))) / 2) / 8)`
 bytes, and interpret it as an integer; reduce the integer modulo `G.Order()` and return the

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -1443,9 +1443,9 @@ most b bits.
 
 ### Random Number Generation Using Extra Random Bits
 
-Generate a random byte array with `l = ceil(((3 * ceil(log2(G.Order()))) / 2) / 8)`
+Generate a random byte array with `L = ceil(((3 * ceil(log2(G.Order()))) / 2) / 8)`
 bytes, and interpret it as an integer; reduce the integer modulo `G.Order()` and return the
-result. See {{I-D.irtf-cfrg-hash-to-curve, Section 5}} for the underlying derivation of `l`.
+result. See {{I-D.irtf-cfrg-hash-to-curve, Section 5}} for the underlying derivation of `L`.
 
 # Application Considerations {#apis}
 

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -1283,7 +1283,7 @@ See {{cryptanalysis}} for related discussion.
     DST = "HashToScalar-" || contextString, and output length 64, interpret
     `uniform_bytes` as a 512-bit integer in little-endian order, and reduce the
     integer modulo `Group.Order()`.
-  - ScalarInverse(s): Returns the multipicative inverse of input Scalar `s` mod `Group.Order()`.
+  - ScalarInverse(s): Returns the multiplicative inverse of input Scalar `s` mod `Group.Order()`.
   - SerializeElement(A): Implemented using the 'Encode' function from Section 5.3.2 of {{!RISTRETTO}}; Ne = 56.
   - DeserializeElement(buf): Implemented using the 'Decode' function from Section 5.3.1 of {{!RISTRETTO}}.
     Additionally, this function validates that the resulting element is not the group

--- a/draft-irtf-cfrg-voprf.md
+++ b/draft-irtf-cfrg-voprf.md
@@ -816,7 +816,7 @@ the protocol with a `DeserializeError` failure.
 
 Applications MUST check that input Element values received over the wire
 are not the group identity element. This check is handled after deserializing
-Element values; see ciphersuite}} for more information and requirements
+Element values; see {{ciphersuites}} for more information and requirements
 on input validation for each ciphersuite.
 
 ### OPRF Protocol {#oprf}


### PR DESCRIPTION
Per @wbl's feedback on the list:

> The one change I'd make is make more clear in 2.1 what the forward reference to 4.2.1 will tell the reader about validation, and capitalize some of those MUSTs in 4.2.1

While reviewing these sections, it seemed better to crib from [FROST](https://cfrg.github.io/draft-irtf-cfrg-frost/draft-irtf-cfrg-frost.html#name-ciphersuites), which makes these steps very explicit as part of the ciphersuite implementation requirements. So I did that and removed redundant text in 4.2.1.

cc @kevinlewi for 👀 